### PR TITLE
Revert "Error handling when plugin not initialized."

### DIFF
--- a/unity_plugin/src/main/java/org/onepf/openiab/UnityProxyActivity.java
+++ b/unity_plugin/src/main/java/org/onepf/openiab/UnityProxyActivity.java
@@ -46,11 +46,6 @@ public class UnityProxyActivity extends Activity {
             String developerPayload = i.getStringExtra("developerPayload");
             boolean inapp = i.getBooleanExtra("inapp", true);
 
-            if (UnityPlugin.instance().getHelper() == null) {
-                Log.e(UnityPlugin.TAG, "OpenIAB UnityPlugin not initialized!");
-                return;
-            }
-
             try {
                 if (inapp) {
                     UnityPlugin.instance().getHelper().launchPurchaseFlow(this, sku, UnityPlugin.RC_REQUEST, UnityPlugin.instance().getPurchaseFinishedListener(), developerPayload);


### PR DESCRIPTION
Reverts onepf/OpenIAB-Unity-Plugin#10
Wrong place to put the code. Should be used before calling of the Activity. Otherwise - an empty screen.
