### PR TITLE
Mock implementation for testing OpenIAB integration in the Unity editor

### DIFF
--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Inventory.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Inventory.cs
@@ -30,6 +30,12 @@ namespace OnePF
         private Dictionary<String, SkuDetails> _skuMap = new Dictionary<String, SkuDetails>();
         private Dictionary<String, Purchase> _purchaseMap = new Dictionary<String, Purchase>();
 
+#if UNITY_EDITOR
+        public Inventory()
+        {
+        }
+#endif
+
         public Inventory(string json)
         {
             var j = new JSON(json);

--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Mock/OpenIAB_Mock.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Mock/OpenIAB_Mock.cs
@@ -1,0 +1,111 @@
+﻿namespace OnePF
+{
+#if UNITY_EDITOR
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Object = UnityEngine.Object;
+
+    public class OpenIAB_Mock : IOpenIAB
+    {
+        #region Fields
+
+        private readonly Dictionary<string, string> skuToStoreSku = new Dictionary<string, string>();
+
+        private readonly Dictionary<string, string> storeSkuToSku = new Dictionary<string, string>();
+
+        private OpenIABEventManager eventManager;
+
+        #endregion
+
+        #region Public Methods and Operators
+
+        public bool areSubscriptionsSupported()
+        {
+            return true;
+        }
+
+        public void consumeProduct(Purchase purchase)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void enableDebugLogging(bool enabled)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void enableDebugLogging(bool enabled, string tag)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void init(Options options)
+        {
+            this.eventManager = Object.FindObjectOfType<OpenIABEventManager>();
+            if (this.eventManager != null)
+            {
+                this.eventManager.SendMessage("OnBillingSupported");
+            }
+        }
+
+        public bool isDebugLog()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void mapSku(string sku, string storeName, string storeSku)
+        {
+            this.skuToStoreSku[sku] = storeSku;
+            this.storeSkuToSku[storeSku] = sku;
+        }
+
+        public void purchaseProduct(string sku, string developerPayload = "")
+        {
+            if (this.eventManager != null)
+            {
+                this.eventManager.SendMessage("OnPurchaseSucceeded", sku);
+            }
+        }
+
+        public void purchaseSubscription(string sku, string developerPayload = "")
+        {
+            this.purchaseProduct(sku, developerPayload);
+        }
+
+        public void queryInventory()
+        {
+            this.queryInventory(this.skuToStoreSku.Keys.ToArray());
+        }
+
+        public void queryInventory(string[] inAppSkus)
+        {
+            // Build fake inventory for testing in editor.
+            var inventory = new Inventory();
+
+            foreach (var sku in inAppSkus)
+            {
+                inventory.AddSkuDetails(
+                    new SkuDetails { Sku = sku, Price = "$9.99", PriceValue = "9.99", CurrencyCode = "$" });
+            }
+
+            if (this.eventManager != null)
+            {
+                this.eventManager.SendMessage("OnQueryInventorySucceeded", inventory);
+            }
+        }
+
+        public void restoreTransactions()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void unbindService()
+        {
+        }
+
+        #endregion
+    }
+#endif
+}

--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/OpenIAB.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/OpenIAB.cs
@@ -36,7 +36,10 @@ namespace OnePF
          */
         static OpenIAB()
         {
-#if UNITY_ANDROID
+#if UNITY_EDITOR
+            _billing = new OpenIAB_Mock();
+            Debug.Log("********** Mock OpenIAB plugin initialized **********");
+#elif UNITY_ANDROID
 			_billing = new OpenIAB_Android();
             Debug.Log("********** Android OpenIAB plugin initialized **********");
 #elif UNITY_IOS

--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/OpenIABEventManager.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/OpenIABEventManager.cs
@@ -89,7 +89,76 @@ public class OpenIABEventManager : MonoBehaviour
         DontDestroyOnLoad(this);
     }
 
-#if UNITY_ANDROID
+#if UNITY_EDITOR
+    private void OnBillingSupported()
+    {
+        if (billingSupportedEvent != null)
+        {
+            billingSupportedEvent();
+        }
+    }
+
+    private void OnBillingNotSupported(string error)
+    {
+        if (billingNotSupportedEvent != null)
+            billingNotSupportedEvent(error);
+    }
+
+    private void OnQueryInventorySucceeded(OnePF.Inventory inventory)
+    {
+        if (queryInventorySucceededEvent != null)
+        {
+            queryInventorySucceededEvent(inventory);
+        }
+    }
+
+    private void OnQueryInventoryFailed(string error)
+    {
+        if (queryInventoryFailedEvent != null)
+            queryInventoryFailedEvent(error);
+    }
+
+    private void OnPurchaseSucceeded(string sku)
+    {
+        if (purchaseSucceededEvent != null)
+        {
+            purchaseSucceededEvent(Purchase.CreateFromSku(sku));
+        }
+    }
+
+    private void OnPurchaseFailed(string error)
+    {
+        if (purchaseFailedEvent != null)
+        {
+            purchaseFailedEvent(-1, error);
+        }
+    }
+
+    private void OnConsumePurchaseSucceeded(string json)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    private void OnConsumePurchaseFailed(string error)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public void OnPurchaseRestored(string sku)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public void OnRestoreFailed(string error)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public void OnRestoreFinished(string message)
+    {
+        throw new System.NotImplementedException();
+    }
+#elif UNITY_ANDROID
     private void OnMapSkuFailed(string exception)
     {
         Debug.LogError("SKU mapping failed: " + exception);
@@ -182,9 +251,7 @@ public class OpenIABEventManager : MonoBehaviour
             restoreSucceededEvent();
         }
     }
-#endif
-
-#if UNITY_IOS
+#elif UNITY_IOS
     private void OnBillingSupported(string empty)
     {
         if (billingSupportedEvent != null)
@@ -265,9 +332,7 @@ public class OpenIABEventManager : MonoBehaviour
             restoreSucceededEvent();
         }
     }
-#endif
-
-#if UNITY_WP8
+#elif UNITY_WP8
     public void OnBillingSupported()
     {
         if (billingSupportedEvent != null)

--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/SkuDetails.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/SkuDetails.cs
@@ -33,7 +33,13 @@ namespace OnePF
         public string CurrencyCode { get; private set; }
         public string PriceValue { get; private set; }
 
-        // Used for Android
+#if UNITY_EDITOR
+        public SkuDetails()
+        {
+        }
+#endif
+
+		// Used for Android
         public SkuDetails(string jsonString)
         {
             var json = new JSON(jsonString);


### PR DESCRIPTION
All code is wrapped in UNITY_EDITOR platform defines to ensure it doesn't interfere with other implementations. 

Required introducing public default constructors for Inventory and SkuDetails classes. 

Note that this implementation does not check the passed store in mapSku. This ensures that the mock works with whatever runtime platform is currently active in the editor.
