### PR TITLE
Crash on Android when initializing OpenIabHelper

### DIFF
--- a/unity_plugin/src/main/java/org/onepf/openiab/UnityPlugin.java
+++ b/unity_plugin/src/main/java/org/onepf/openiab/UnityPlugin.java
@@ -149,6 +149,10 @@ public class UnityPlugin {
         });
     }
 
+    public void queryInventory(final Object[] itemSkus) {
+        queryInventory(Arrays.copyOf(itemSkus, itemSkus.length, String[].class));
+    }
+
     public void queryInventory(final String[] itemSkus) {
         UnityPlayer.currentActivity.runOnUiThread(new Runnable() {
             @Override
@@ -156,6 +160,13 @@ public class UnityPlugin {
                 _helper.queryInventoryAsync(true, Arrays.asList(itemSkus), _queryInventoryListener);
             }
         });
+    }
+
+    public void queryInventory(final Object[] itemSkus, final Object[] subsSkus) {
+        queryInventory(
+            Arrays.copyOf(itemSkus, itemSkus.length, String[].class),
+            Arrays.copyOf(subsSkus, subsSkus.length, String[].class)
+        );
     }
 
     public void queryInventory(final String[] itemSkus, final String[] subsSkus) {

--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Android/OpenIAB_Android.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Android/OpenIAB_Android.cs
@@ -144,12 +144,12 @@ namespace OnePF
                 foreach (var pair in options.storeKeys)
                     j_optionsBuilder.Call<AndroidJavaObject>("addStoreKey", pair.Key, pair.Value);
 
-                var addPreferredStoreNameMethod = AndroidJNI.GetMethodID(clazz, "addPreferredStoreName", "([Ljava/lang/String;)Lorg/onepf/oms/OpenIabHelper$Options$Builder;");
+                var addPreferredStoreNameMethod = AndroidJNI.GetMethodID(clazz, "addPreferredStoreName", "([Ljava/lang/Object;)Lorg/onepf/oms/OpenIabHelper$Options$Builder;");
                 var prms = new jvalue[1];
                 prms[0].l = AndroidJNIHelper.ConvertToJNIArray(options.prefferedStoreNames);
                 AndroidJNI.CallObjectMethod(objPtr, addPreferredStoreNameMethod, prms);
 
-                var addAvailableStoreNameMethod = AndroidJNI.GetMethodID(clazz, "addAvailableStoreNames", "([Ljava/lang/String;)Lorg/onepf/oms/OpenIabHelper$Options$Builder;");
+                var addAvailableStoreNameMethod = AndroidJNI.GetMethodID(clazz, "addAvailableStoreNames", "([Ljava/lang/Object;)Lorg/onepf/oms/OpenIabHelper$Options$Builder;");
                 prms = new jvalue[1];
                 prms[0].l = AndroidJNIHelper.ConvertToJNIArray(options.availableStoreNames);
                 AndroidJNI.CallObjectMethod(objPtr, addAvailableStoreNameMethod, prms);
@@ -225,7 +225,7 @@ namespace OnePF
                 return;
             }
             jvalue[] args = AndroidJNIHelper.CreateJNIArgArray(new object[] { inAppSkus, subsSkus });
-            IntPtr methodId = AndroidJNI.GetMethodID(_plugin.GetRawClass(), "queryInventory", "([Ljava/lang/String;[Ljava/lang/String;)V");
+            IntPtr methodId = AndroidJNI.GetMethodID(_plugin.GetRawClass(), "queryInventory", "([Ljava/lang/Object;[Ljava/lang/Object;)V");
             AndroidJNI.CallVoidMethod(_plugin.GetRawObject(), methodId, args);
         }
 
@@ -281,13 +281,13 @@ namespace OnePF
             _plugin.Call("enableDebugLogging", enabled, tag);
         }
 #else
-		static OpenIAB_Android() {
+        static OpenIAB_Android() {
             STORE_GOOGLE = "STORE_GOOGLE";
             STORE_AMAZON = "STORE_AMAZON";
             STORE_SAMSUNG = "STORE_SAMSUNG";
             STORE_NOKIA = "STORE_NOKIA";
             STORE_YANDEX = "STORE_YANDEX";
-		}
+        }
 #endif
     }
 }


### PR DESCRIPTION
I'm integrating OpenIAB and the Unity Plugin into my Unity project and have run into an issue when initializing the OpenIabHelper on a Nexus 10 tablet. I'm using version 0.9.8.2 of OpenIAB and the Unity plugin.

Things are working well on a Kindle Fire HDX and prior, they were working well on this very same device with version 0.9.7.2 of OpenIAB and the Unity plugin.

At the bottom of this issue is the complete stack trace. The curious bit is here:

```
E/art     ( 7900): JNI ERROR (app bug): attempt to pass an instance of java.lang.Object[] as argument 1 to org.onepf.oms.OpenIabHelper$Options$Builder org.onepf.oms.OpenIabHelper$Options$Builder.addPreferredStoreName(java.lang.String[])
F/art     ( 7900): art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: bad arguments passed to org.onepf.oms.OpenIabHelper$Options$Builder org.onepf.oms.OpenIabHelper$Options$Builder.addPreferredStoreName(java.lang.String[]) (see above for details)
```

Please excuse me as I am new to both Java and the AndroidJNI, but it seems that the `AndroidJNIHelper.ConvertToJNIArray/1` function is [converting c# string arrays to Java object arrays](https://github.com/onepf/OpenIAB-Unity-Plugin/blob/master/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Android/OpenIAB_Android.cs#L147-L150). I'm not sure if this is the intended behaviour or why things are working well on the Kindle Fire when they're both using the same Android codepaths.

Thank you very much for providing this library, it has been super helpful.

Complete stacktrace:

```
I/Unity   ( 7900): ********** Android OpenIAB plugin initialized **********
I/Unity   ( 7900): UnityEngine.Debug:Internal_Log(Int32, String, Object)
I/Unity   ( 7900): UnityEngine.Debug:Log(Object)
I/Unity   ( 7900): OnePF.OpenIAB:.cctor() (at /Volumes/Build/opt/jenkins/workspace/daemon-stage-6-client-build-app-android/projects/Kaiju/Assets/Plugins/OpenIAB/OpenIAB.cs:41)
I/Unity   ( 7900): UL.Kaiju.Store.AndroidStore:.ctor() (at /Volumes/Build/opt/jenkins/workspace/daemon-stage-6-client-build-app-android/projects/Kaiju/Assets/UL/Kaiju/Store/PaymentGateways/AndroidStore.cs:44)
I/Unity   ( 7900): UL.Kaiju.Store.AndroidStore:.ctor() (at /Volumes/Build/opt/jenkins/workspace/daemon-stage-6-client-build-app-android/projects/Kaiju/Assets/UL/Kaiju/Store/PaymentGateways/AndroidStore.cs:44)
I/Unity   ( 7900): UL.Kaiju.Store.PaymentGateway:Create() (at /Volumes/Build/opt/jenkins/workspace/daemon-stage-6-client-build-app-android/projects/Kaiju/Assets/UL/Kaiju/Store/PaymentGateway.cs:21)
I/Unity   ( 7900): StoreClient:get_PaymentGateWay() (at /Volumes/Build/opt/jenkins/workspace/daemon-stage-6-client-build-app-android/projects/Kaiju/Assets/UL/Kaiju/Store/StoreClient.cs:
E/art     ( 7900): JNI ERROR (app bug): attempt to pass an instance of java.lang.Object[] as argument 1 to org.onepf.oms.OpenIabHelper$Options$Builder org.onepf.oms.OpenIabHelper$Options$Builder.addPreferredStoreName(java.lang.String[])
F/art     ( 7900): art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: bad arguments passed to org.onepf.oms.OpenIabHelper$Options$Builder org.onepf.oms.OpenIabHelper$Options$Builder.addPreferredStoreName(java.lang.String[]) (see above for details)
F/art     ( 7900): art/runtime/check_jni.cc:65]     from boolean com.unity3d.player.UnityPlayer.nativeRender()
F/art     ( 7900): art/runtime/check_jni.cc:65] "UnityMain" prio=5 tid=13 Runnable
F/art     ( 7900): art/runtime/check_jni.cc:65]   | group="main" sCount=0 dsCount=0 obj=0x12c29d60 self=0xb87c16a8
F/art     ( 7900): art/runtime/check_jni.cc:65]   | sysTid=7919 nice=0 cgrp=apps sched=0/0 handle=0xb87c1c98
F/art     ( 7900): art/runtime/check_jni.cc:65]   | state=R schedstat=( 33138884712 12700052575 101108 ) utm=2829 stm=484 core=0 HZ=100
F/art     ( 7900): art/runtime/check_jni.cc:65]   | stack=0xafe79000-0xafe7b000 stackSize=1036KB
F/art     ( 7900): art/runtime/check_jni.cc:65]   | held mutexes= "mutator lock"(shared held)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #00 pc 00004c58  /system/lib/libbacktrace_libc++.so (UnwindCurrent::Unwind(unsigned int, ucontext*)+23)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #01 pc 000034c1  /system/lib/libbacktrace_libc++.so (Backtrace::Unwind(unsigned int, ucontext*)+8)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #02 pc 00252745  /system/lib/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, int, char const*, art::mirror::ArtMethod*)+84)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #03 pc 00236223  /system/lib/libart.so (art::Thread::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char> >&) const+162)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #04 pc 000b1285  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #05 pc 000b19b5  /system/lib/libart.so (art::JniAbortF(char const*, char const*, ...)+68)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #06 pc 00072787  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #07 pc 002227f7  /system/lib/libart.so (art::InvokeVirtualOrInterfaceWithJValues(art::ScopedObjectAccessAlreadyRunnable const&, art::mirror::Object*, _jmethodID*, jvalue*)+698)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #08 pc 001d6c01  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #09 pc 000b9b3f  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #10 pc 004b8cc8  /data/app/com.undeadlabs.daemon.stage-2/lib/arm/libunity.so (AndroidJNI_CUSTOM_CallObjectMethod(void*, void*, MonoArray*)+484)
F/art     ( 7900): art/runtime/check_jni.cc:65]   native: #11 pc 00002764   (???)
F/art     ( 7900): art/runtime/check_jni.cc:65]   at com.unity3d.player.UnityPlayer.nativeRender(Native method)
F/art     ( 7900): art/runtime/check_jni.cc:65]   at com.unity3d.player.UnityPlayer.a(unavailable:-1)
F/art     ( 7900): art/runtime/check_jni.cc:65]   at com.unity3d.player.UnityPlayer$a.run(unavailable:-1)
F/art     ( 7900): art/runtime/check_jni.cc:65] 
F/art     ( 7900): art/runtime/runtime.cc:284] Runtime aborting...
F/art     ( 7900): art/runtime/runtime.cc:284] Aborting thread:
F/art     ( 7900): art/runtime/runtime.cc:284] "UnityMain" prio=5 tid=13 Native
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c29d60 self=0xb87c16a8
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7919 nice=0 cgrp=apps sched=0/0 handle=0xb87c1c98
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=R schedstat=( 33167692753 12709731074 101211 ) utm=2830 stm=486 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xafe79000-0xafe7b000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes= "abort lock" "mutator lock"(shared held)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00004c58  /system/lib/libbacktrace_libc++.so (UnwindCurrent::Unwind(unsigned int, ucontext*)+23)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000034c1  /system/lib/libbacktrace_libc++.so (Backtrace::Unwind(unsigned int, ucontext*)+8)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 00252745  /system/lib/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, int, char const*, art::mirror::ArtMethod*)+84)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 00236223  /system/lib/libart.so (art::Thread::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char> >&) const+162)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00225c11  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00225eb3  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #06 pc 00226073  /system/lib/libart.so (art::Runtime::Abort()+82)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #07 pc 000a7359  /system/lib/libart.so (art::LogMessage::~LogMessage()+1360)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #08 pc 000b1471  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #09 pc 000b19b5  /system/lib/libart.so (art::JniAbortF(char const*, char const*, ...)+68)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #10 pc 00072787  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #11 pc 002227f7  /system/lib/libart.so (art::InvokeVirtualOrInterfaceWithJValues(art::ScopedObjectAccessAlreadyRunnable const&, art::mirror::Object*, _jmethodID*, jvalue*)+698)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #12 pc 001d6c01  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #13 pc 000b9b3f  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #14 pc 004b8cc8  /data/app/com.undeadlabs.daemon.stage-2/lib/arm/libunity.so (AndroidJNI_CUSTOM_CallObjectMethod(void*, void*, MonoArray*)+484)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #15 pc 00002764   (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   at com.unity3d.player.UnityPlayer.nativeRender(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   at com.unity3d.player.UnityPlayer.a(unavailable:-1)
F/art     ( 7900): art/runtime/runtime.cc:284]   at com.unity3d.player.UnityPlayer$a.run(unavailable:-1)
F/art     ( 7900): art/runtime/runtime.cc:284] Dumping all threads without appropriate locks held: thread list lock mutator lock
F/art     ( 7900): art/runtime/runtime.cc:284] All threads:
F/art     ( 7900): art/runtime/runtime.cc:284] DALVIK THREADS (27):
F/art     ( 7900): art/runtime/runtime.cc:284] "main" prio=5 tid=1 Native
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x72b4b2e0 self=0xb851c518
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7900 nice=0 cgrp=apps sched=0/0 handle=0xb6f84ec8
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 313987790 207813284 1002 ) utm=17 stm=14 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xbe206000-0xbe208000 stackSize=8MB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 0003c5d4  /system/lib/libc.so (__epoll_pwait+20)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 00013f41  /system/lib/libc.so (epoll_pwait+26)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 00013f4f  /system/lib/libc.so (epoll_wait+6)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 000123c3  /system/lib/libutils.so (android::Looper::pollInner(int)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 000125ed  /system/lib/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+92)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 0007fb61  /system/lib/libandroid_runtime.so (android::NativeMessageQueue::pollOnce(_JNIEnv*, int)+22)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #06 pc 000b0dc7  /data/dalvik-cache/arm/system@framework@boot.oat (Java_android_os_MessageQueue_nativePollOnce__JI+102)
F/art     ( 7900): art/runtime/runtime.cc:284]   at android.os.MessageQueue.nativePollOnce(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   at android.os.MessageQueue.next(MessageQueue.java:143)
F/art     ( 7900): art/runtime/runtime.cc:284]   at android.os.Looper.loop(Looper.java:122)
F/art     ( 7900): art/runtime/runtime.cc:284]   at android.app.ActivityThread.main(ActivityThread.java:5221)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.reflect.Method.invoke!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.reflect.Method.invoke(Method.java:372)
F/art     ( 7900): art/runtime/runtime.cc:284]   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:899)
F/art     ( 7900): art/runtime/runtime.cc:284]   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "Heap thread pool worker thread 0" prio=5 tid=2 Native (still starting up)
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x0 self=0xb876f288
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7906 nice=0 cgrp=apps sched=0/0 handle=0xb8763d58
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 3961665 1750585 17 ) utm=0 stm=0 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb4a71000-0xb4a73000 stackSize=1020KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 0024065d  /system/lib/libart.so (art::ThreadPool::GetTask(art::Thread*)+64)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 002405f7  /system/lib/libart.so (art::ThreadPoolWorker::Run()+62)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00240ee5  /system/lib/libart.so (art::ThreadPoolWorker::Callback(void*)+60)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00015ccf  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #06 pc 00013ca3  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   (no managed stack frames)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "Signal Catcher" prio=5 tid=3 WaitingInMainSignalCatcherLoop
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c00080 self=0xb85213b0
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7907 nice=0 cgrp=apps sched=0/0 handle=0xb876f660
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 2119666 1346251 12 ) utm=0 stm=0 core=0 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb496d000-0xb496f000 stackSize=1012KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 0003c2f8  /system/lib/libc.so (__rt_sigtimedwait+12)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 00017411  /system/lib/libc.so (sigwait+24)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 0022937b  /system/lib/libart.so (art::SignalCatcher::WaitForSignal(art::Thread*, art::SignalSet&)+86)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 0022af05  /system/lib/libart.so (art::SignalCatcher::Run(void*)+212)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00015ccf  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00013ca3  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   (no managed stack frames)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "JDWP" prio=5 tid=4 WaitingInMainDebuggerLoop
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c0d080 self=0xb87649a8
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7908 nice=0 cgrp=apps sched=0/0 handle=0xb8764760
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 1523875 159541 5 ) utm=0 stm=0 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb4869000-0xb486b000 stackSize=1012KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 0003b63c  /system/lib/libc.so (recvmsg+8)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 00296903  /system/lib/libart.so (art::JDWP::JdwpAdbState::ReceiveClientFd()+102)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 00296a0d  /system/lib/libart.so (art::JDWP::JdwpAdbState::Accept()+116)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 00195ff5  /system/lib/libart.so (art::JDWP::JdwpState::Run()+300)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00197579  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00015ccf  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #06 pc 00013ca3  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   (no managed stack frames)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "ReferenceQueueDaemon" prio=5 tid=5 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c2a080 self=0xb876dfc8
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7909 nice=0 cgrp=apps sched=0/0 handle=0xb876e3a0
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 6883166 5921293 30 ) utm=0 stm=0 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb475f000-0xb4761000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 002043a9  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000003d3  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__+82)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   - waiting on <0x10157191> (a java.lang.Class<java.lang.ref.ReferenceQueue>)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Daemons$ReferenceQueueDaemon.run(Daemons.java:133)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x10157191> (a java.lang.Class<java.lang.ref.ReferenceQueue>)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.run(Thread.java:818)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "FinalizerWatchdogDaemon" prio=5 tid=6 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c2a140 self=0xb876ecc8
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7911 nice=0 cgrp=apps sched=0/0 handle=0xb876d218
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 1506623 1027459 17 ) utm=0 stm=0 core=0 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb4551000-0xb4553000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 002043a9  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000003d3  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__+82)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   - waiting on <0x08e1b8f6> (a java.lang.Daemons$FinalizerWatchdogDaemon)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Daemons$FinalizerWatchdogDaemon.waitForObject(Daemons.java:239)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x08e1b8f6> (a java.lang.Daemons$FinalizerWatchdogDaemon)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Daemons$FinalizerWatchdogDaemon.run(Daemons.java:211)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.run(Thread.java:818)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "FinalizerDaemon" prio=5 tid=7 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c2a0e0 self=0xb8771350
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7910 nice=0 cgrp=apps sched=0/0 handle=0xb876ea80
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 17085125 22846085 66 ) utm=0 stm=1 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb4655000-0xb4657000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00204371  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000005f7  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__JI+102)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   - waiting on <0x12bae4f7> (a java.lang.ref.ReferenceQueue)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait(Object.java:422)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:101)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x12bae4f7> (a java.lang.ref.ReferenceQueue)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:72)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Daemons$FinalizerDaemon.run(Daemons.java:173)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.run(Thread.java:818)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "GCDaemon" prio=5 tid=8 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c2a200 self=0xb876fc40
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7913 nice=0 cgrp=apps sched=0/0 handle=0xb8770018
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 162396542 119490121 399 ) utm=12 stm=3 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb4341000-0xb4343000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 002043a9  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000003d3  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__+82)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   - waiting on <0x3960ef64> (a java.lang.Daemons$GCDaemon)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Daemons$GCDaemon.run(Daemons.java:341)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x3960ef64> (a java.lang.Daemons$GCDaemon)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.run(Thread.java:818)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "HeapTrimmerDaemon" prio=5 tid=9 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c2a1a0 self=0xb876d460
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7912 nice=0 cgrp=apps sched=0/0 handle=0xb876d940
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 9373083 12855210 52 ) utm=0 stm=0 core=0 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb4445000-0xb4447000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 002043a9  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000003d3  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__+82)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   - waiting on <0x028e95cd> (a java.lang.Daemons$HeapTrimmerDaemon)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Daemons$HeapTrimmerDaemon.run(Daemons.java:310)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x028e95cd> (a java.lang.Daemons$HeapTrimmerDaemon)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.run(Thread.java:818)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "Binder_1" prio=5 tid=10 Native
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c66080 self=0xb8774f80
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7914 nice=0 cgrp=apps sched=0/0 handle=0xb8770730
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 90446661 181869253 1245 ) utm=1 stm=8 core=0 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb4135000-0xb4137000 stackSize=1012KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 0003cb54  /system/lib/libc.so (__ioctl+8)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 00041fd1  /system/lib/libc.so (ioctl+14)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 0001f39b  /system/lib/libbinder.so (android::IPCThreadState::talkWithDriver(bool)+138)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 0001f88b  /system/lib/libbinder.so (android::IPCThreadState::getAndExecuteCommand()+6)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 0001f8ed  /system/lib/libbinder.so (android::IPCThreadState::joinThreadPool(bool)+48)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00023a5b  /system/lib/libbinder.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #06 pc 000104d5  /system/lib/libutils.so (android::Thread::_threadLoop(void*)+112)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #07 pc 0005df4d  /system/lib/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell(void*)+72)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #08 pc 00010045  /system/lib/libutils.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #09 pc 00015ccf  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #10 pc 00013ca3  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   (no managed stack frames)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "Binder_2" prio=5 tid=11 Native
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c6a080 self=0xb87759b0
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7915 nice=0 cgrp=apps sched=0/0 handle=0xb8775768
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 89380795 236811865 1286 ) utm=1 stm=7 core=0 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb4031000-0xb4033000 stackSize=1012KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 0003cb54  /system/lib/libc.so (__ioctl+8)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 00041fd1  /system/lib/libc.so (ioctl+14)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 0001f39b  /system/lib/libbinder.so (android::IPCThreadState::talkWithDriver(bool)+138)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 0001f88b  /system/lib/libbinder.so (android::IPCThreadState::getAndExecuteCommand()+6)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 0001f8ed  /system/lib/libbinder.so (android::IPCThreadState::joinThreadPool(bool)+48)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00023a5b  /system/lib/libbinder.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #06 pc 000104d5  /system/lib/libutils.so (android::Thread::_threadLoop(void*)+112)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #07 pc 0005df4d  /system/lib/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell(void*)+72)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #08 pc 00010045  /system/lib/libutils.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #09 pc 00015ccf  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #10 pc 00013ca3  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   (no managed stack frames)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "Thread-2852" prio=5 tid=12 Native
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12d88080 self=0xb87ba1e8
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7916 nice=0 cgrp=apps sched=0/0 handle=0xb87b9fa0
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 4557493 3648751 89 ) utm=0 stm=0 core=0 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xb3e74000-0xb3e76000 stackSize=1012KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 0003cc20  /system/lib/libc.so (nanosleep+12)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 00023ff7  /system/lib/libc.so (sleep+38)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 00002c94  /data/app/com.undeadlabs.daemon.stage-2/lib/arm/libmain.so (instance_app_main(APP_INSTANCE*, _JNIEnv*)+452)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 00004000  /data/app/com.undeadlabs.daemon.stage-2/lib/arm/libmain.so (app_thread_entry(void*)+168)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00015ccf  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00013ca3  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   (no managed stack frames)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "UnityMain" prio=5 tid=13 Native
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c29d60 self=0xb87c16a8
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7919 nice=0 cgrp=apps sched=0/0 handle=0xb87c1c98
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=R schedstat=( 33392494760 12792381941 101642 ) utm=2839 stm=500 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xafe79000-0xafe7b000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes= "abort lock"
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00004c58  /system/lib/libbacktrace_libc++.so (UnwindCurrent::Unwind(unsigned int, ucontext*)+23)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000034c1  /system/lib/libbacktrace_libc++.so (Backtrace::Unwind(unsigned int, ucontext*)+8)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 00252745  /system/lib/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, int, char const*, art::mirror::ArtMethod*)+84)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 00236223  /system/lib/libart.so (art::Thread::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char> >&) const+162)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 0023f3b5  /system/lib/libart.so (art::ThreadList::DumpLocked(std::__1::basic_ostream<char, std::__1::char_traits<char> >&)+120)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00225e29  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #06 pc 00226073  /system/lib/libart.so (art::Runtime::Abort()+82)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #07 pc 000a7359  /system/lib/libart.so (art::LogMessage::~LogMessage()+1360)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #08 pc 000b1471  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #09 pc 000b19b5  /system/lib/libart.so (art::JniAbortF(char const*, char const*, ...)+68)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #10 pc 00072787  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #11 pc 002227f7  /system/lib/libart.so (art::InvokeVirtualOrInterfaceWithJValues(art::ScopedObjectAccessAlreadyRunnable const&, art::mirror::Object*, _jmethodID*, jvalue*)+698)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #12 pc 001d6c01  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #13 pc 000b9b3f  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #14 pc 004b8cc8  /data/app/com.undeadlabs.daemon.stage-2/lib/arm/libunity.so (AndroidJNI_CUSTOM_CallObjectMethod(void*, void*, MonoArray*)+484)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #15 pc 00002764   (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   at com.unity3d.player.UnityPlayer.nativeRender(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   at com.unity3d.player.UnityPlayer.a(unavailable:-1)
F/art     ( 7900): art/runtime/runtime.cc:284]   at com.unity3d.player.UnityPlayer$a.run(unavailable:-1)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "FMODAudioDevice" prio=5 tid=14 Native
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12d55ca0 self=0xb87d8910
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7920 nice=0 cgrp=apps sched=0/0 handle=0xb87d8fb0
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 357007336 217183327 2465 ) utm=27 stm=8 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xa287c000-0xa287e000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 0004d4ed  /system/lib/libmedia.so (android::ClientProxy::obtainBuffer(android::Proxy::Buffer*, timespec const*, timespec*)+580)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 0004c099  /system/lib/libmedia.so (android::AudioTrack::obtainBuffer(android::AudioTrack::Buffer*, timespec const*, timespec*, unsigned int*)+212)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 0004c267  /system/lib/libmedia.so (android::AudioTrack::write(void const*, unsigned int, bool)+162)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00097faf  /system/lib/libandroid_runtime.so (writeToTrack(android::sp<android::AudioTrack> const&, int, signed char const*, int, int, bool)+54)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00098f7b  /system/lib/libandroid_runtime.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #06 pc 008bbca7  /data/dalvik-cache/arm/system@framework@boot.oat (Java_android_media_AudioTrack_native_1write_1byte___3BIIIZ+134)
F/art     ( 7900): art/runtime/runtime.cc:284]   at android.media.AudioTrack.native_write_byte(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   at android.media.AudioTrack.write(AudioTrack.java:1255)
F/art     ( 7900): art/runtime/runtime.cc:284]   at org.fmod.FMODAudioDevice.run(unavailable:-1)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.run(Thread.java:818)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "AudioTrack" prio=5 tid=15 Native
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12de7080 self=0xb8bdcf38
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7933 nice=-16 cgrp=apps sched=0/0 handle=0xb8bead90
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 4316376 13960085 80 ) utm=0 stm=0 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xa180b000-0xa180d000 stackSize=1012KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012444  /system/lib/libc.so (syscall+32)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 00015ba1  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 0004c867  /system/lib/libmedia.so (android::AudioTrack::AudioTrackThread::threadLoop()+118)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 000104d5  /system/lib/libutils.so (android::Thread::_threadLoop(void*)+112)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 0005df4d  /system/lib/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell(void*)+72)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 00010045  /system/lib/libutils.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #06 pc 00015ccf  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #07 pc 00013ca3  /system/lib/libc.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   (no managed stack frames)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "Timer-0" prio=5 tid=16 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12db9510 self=0xb88ed030
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7935 nice=0 cgrp=apps sched=0/0 handle=0xb9aa34c8
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 1025167 172958 4 ) utm=0 stm=0 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xa0f9f000-0xa0fa1000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 002043a9  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x31e86e82> (a java.util.Timer$TimerImpl)
F/art     ( 7900): art/runtime/runtime.cc:284] "pool-1-thread-1" prio=5 tid=17 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 11561171 16041706 54 ) utm=1 stm=0 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00204371  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x0c2ed993> (a java.lang.Object)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.locks.LockSupport.park(LockSupport.java:157)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1035)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7948 nice=0 cgrp=apps sched=0/0 handle=0xb9de2c98
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xa0a99000-0xa0a9b000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012444  /system/lib/libc.so (syscall+32)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000005f7  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__JI+102)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.parkFor(Thread.java:1220)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.LinkedBlockingQueue.poll(LinkedBlockingQueue.java:435)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1097)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "AsyncTask #1" prio=5 tid=20 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12c6a3e0 self=0xb9fcd668
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0xa07c9000-0xa07cb000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000005f7  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__JI+102)
F/art     ( 7900): art/runtime/runtime.cc:284]   at sun.misc.Unsafe.park(Unsafe.java:299)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2016)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1097)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "Timer-1" prio=5 tid=21 TimedWaiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x1331c2b0 self=0xb9fd5af8
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012444  /system/lib/libc.so (syscall+32)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000005f7  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__JI+102)
F/art     ( 7900): art/runtime/runtime.cc:284]   - waiting on <0x28b2f0ce> (a java.util.Timer$TimerImpl)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.Timer$TimerImpl.run(Timer.java:238)
F/art     ( 7900): art/runtime/runtime.cc:284] "Timer-2" prio=5 tid=22 TimedWaiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=7954 nice=0 cgrp=apps sched=0/0 handle=0xb9fd8830
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012444  /system/lib/libc.so (syscall+32)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000005f7  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__JI+102)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait(Object.java:422)
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x134ddd00 self=0xba7b9510
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 9375377 33019831 20 ) utm=0 stm=0 core=1 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00204371  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   - waiting on <0x2878c6fc> (a java.lang.Object)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x2878c6fc> (a java.lang.Object)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.locks.LockSupport.park(LockSupport.java:157)
F/art     ( 7900): art/runtime/runtime.cc:284]   at com.google.analytics.tracking.android.GAThread.run(GAThread.java:382)
F/art     ( 7900): art/runtime/runtime.cc:284] "AsyncTask #2" prio=5 tid=23 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 249196737 718305884 1216 ) utm=18 stm=6 core=0 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00204371  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait(Object.java:422)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:101)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x38914bda> (a java.lang.ref.ReferenceQueue)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:72)
F/art     ( 7900): art/runtime/runtime.cc:284]   at org.apache.http.impl.conn.tsccm.RefQueueWorker.run(RefQueueWorker.java:102)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.run(Thread.java:818)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "RefQueueWorker@org.apache.http.impl.conn.tsccm.ConnPoolByRoute@280bcf55" prio=5 tid=25 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x12fa0d60 self=0xba85e9f8
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=8065 nice=10 cgrp=apps/bg_non_interactive sched=0/0 handle=0xba85edd0
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0x9d083000-0x9d085000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00204371  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000005f7  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__JI+102)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   - waiting on <0x1f95e80b> (a java.lang.ref.ReferenceQueue)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait(Object.java:422)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:101)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x1f95e80b> (a java.lang.ref.ReferenceQueue)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:72)
F/art     ( 7900): art/runtime/runtime.cc:284]   at org.apache.http.impl.conn.tsccm.RefQueueWorker.run(RefQueueWorker.java:102)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.run(Thread.java:818)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "AsyncTask #3" prio=5 tid=26 Waiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x1352d880 self=0xbaa83bf8
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=8101 nice=10 cgrp=apps/bg_non_interactive sched=0/0 handle=0xbaa840d8
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 82068246 83127585 208 ) utm=7 stm=1 core=0 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0x9c72e000-0x9c730000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012440  /system/lib/libc.so (syscall+28)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000aa093  /system/lib/libart.so (art::ConditionVariable::Wait(art::Thread*)+98)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #02 pc 001f57f1  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, long long, int, bool, art::ThreadState)+1036)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #03 pc 001f6eb5  /system/lib/libart.so (art::Monitor::Wait(art::Thread*, art::mirror::Object*, long long, int, bool, art::ThreadState)+136)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #04 pc 00204371  /system/lib/libart.so (???)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #05 pc 000005f7  /data/dalvik-cache/arm/system@framework@boot.oat (Java_java_lang_Object_wait__JI+102)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Object.wait!(Native method)
F/art     ( 7900): art/runtime/runtime.cc:284]   - waiting on <0x230956e8> (a java.lang.Object)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.parkFor(Thread.java:1220)
F/art     ( 7900): art/runtime/runtime.cc:284]   - locked <0x230956e8> (a java.lang.Object)
F/art     ( 7900): art/runtime/runtime.cc:284]   at sun.misc.Unsafe.park(Unsafe.java:299)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.locks.LockSupport.park(LockSupport.java:157)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2016)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:410)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1035)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1097)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
F/art     ( 7900): art/runtime/runtime.cc:284]   at java.lang.Thread.run(Thread.java:818)
F/art     ( 7900): art/runtime/runtime.cc:284] 
F/art     ( 7900): art/runtime/runtime.cc:284] "disconnect check" prio=5 tid=27 TimedWaiting
F/art     ( 7900): art/runtime/runtime.cc:284]   | group="" sCount=0 dsCount=0 obj=0x13020390 self=0xbaa479e0
F/art     ( 7900): art/runtime/runtime.cc:284]   | sysTid=8107 nice=0 cgrp=apps sched=0/0 handle=0xbaa47e48
F/art     ( 7900): art/runtime/runtime.cc:284]   | state=S schedstat=( 2123499 8776751 19 ) utm=0 stm=0 core=0 HZ=100
F/art     ( 7900): art/runtime/runtime.cc:284]   | stack=0x9c62a000-0x9c62c000 stackSize=1036KB
F/art     ( 7900): art/runtime/runtime.cc:284]   | held mutexes=
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #00 pc 00012444  /system/lib/libc.so (syscall+32)
F/art     ( 7900): art/runtime/runtime.cc:284]   native: #01 pc 000a9e1f  /system/lib/libart.so (art::ConditionVariable::TimedWait(art::Thread*, long long, int)+118)
F/libc    ( 7900): Fatal signal 6 (SIGABRT), code -6 in tid 7919 (UnityMain)
I/DEBUG   (  122): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
I/DEBUG   (  122): Build fingerprint: 'google/mantaray/manta:5.0/LRX21P/1570855:user/release-keys'
I/DEBUG   (  122): Revision: '8'
I/DEBUG   (  122): ABI: 'arm'
I/DEBUG   (  122): pid: 7900, tid: 7919, name: UnityMain  >>> com.undeadlabs.daemon.stage <<<
I/DEBUG   (  122): signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
I/DEBUG   (  122): Abort message: 'art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: bad arguments passed to org.onepf.oms.OpenIabHelper$Options$Builder org.onepf.oms.OpenIabHelper$Options$Builder.addPreferredStoreName(java.lang.String[]) (see above for details)'
I/DEBUG   (  122):     r0 00000000  r1 00001eef  r2 00000006  r3 00000000
I/DEBUG   (  122):     r4 aff7add8  r5 00000006  r6 0000000b  r7 0000010c
I/DEBUG   (  122):     r8 00000000  r9 b8512968  sl b87c16a8  fp 00000001
I/DEBUG   (  122):     ip 00001eef  sp aff79c30  lr b6f214e5  pc b6f47950  cpsr 60070010
I/DEBUG   (  122): 
I/DEBUG   (  122): backtrace:
I/DEBUG   (  122):     #00 pc 0003c950  /system/lib/libc.so (tgkill+12)
I/DEBUG   (  122):     #01 pc 000164e1  /system/lib/libc.so (pthread_kill+52)
I/DEBUG   (  122):     #02 pc 000170f3  /system/lib/libc.so (raise+10)
I/DEBUG   (  122):     #03 pc 00013945  /system/lib/libc.so
I/DEBUG   (  122):     #04 pc 00011fe4  /system/lib/libc.so (abort+4)
I/DEBUG   (  122):     #05 pc 002260cb  /system/lib/libart.so (art::Runtime::Abort()+170)
I/DEBUG   (  122):     #06 pc 000a7359  /system/lib/libart.so (art::LogMessage::~LogMessage()+1360)
I/DEBUG   (  122):     #07 pc 000b1471  /system/lib/libart.so
I/DEBUG   (  122):     #08 pc 000b19b5  /system/lib/libart.so (art::JniAbortF(char const*, char const*, ...)+68)
I/DEBUG   (  122):     #09 pc 00072787  /system/lib/libart.so
I/DEBUG   (  122):     #10 pc 002227f7  /system/lib/libart.so (art::InvokeVirtualOrInterfaceWithJValues(art::ScopedObjectAccessAlreadyRunnable const&, art::mirror::Object*, _jmethodID*, jvalue*)+698)
I/DEBUG   (  122):     #11 pc 001d6c01  /system/lib/libart.so
I/DEBUG   (  122):     #12 pc 000b9b3f  /system/lib/libart.so
I/DEBUG   (  122):     #13 pc 004b8cc8  /data/app/com.undeadlabs.daemon.stage-2/lib/arm/libunity.so (AndroidJNI_CUSTOM_CallObjectMethod(void*, void*, MonoArray*)+484)
I/DEBUG   (  122):     #14 pc 00002764  <unknown>
I/AudioFlinger(  124): BUFFER TIMEOUT: remove(4098) from active list on thread 0xb5ec4008
I/DEBUG   (  122): 
I/DEBUG   (  122): Tombstone written to: /data/tombstones/tombstone_03
```