### PR TITLE
iOS server-side IAP validation

### DIFF
--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/OpenIABEventManager.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/OpenIABEventManager.cs
@@ -214,11 +214,11 @@ public class OpenIABEventManager : MonoBehaviour
             queryInventoryFailedEvent(error);
     }
 
-    private void OnPurchaseSucceeded(string sku)
+    private void OnPurchaseSucceeded(string json)
     {
         if (purchaseSucceededEvent != null)
         {
-            purchaseSucceededEvent(Purchase.CreateFromSku(OpenIAB_iOS.StoreSku2Sku(sku)));
+            purchaseSucceededEvent(new Purchase(json));
         }
     }
 

--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Purchase.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Purchase.cs
@@ -65,6 +65,10 @@ namespace OnePF
         /// Current store name
         /// </summary>
         public string AppstoreName { get; private set; }
+        /// <summary>
+        /// Purchase Receipt of the order (iOS only)
+        /// </summary>
+        public string Receipt { get; private set;}
 
         private Purchase()
         {
@@ -88,6 +92,7 @@ namespace OnePF
             OriginalJson = json.ToString("originalJson");
             Signature = json.ToString("signature");
             AppstoreName = json.ToString("appstoreName");
+			Receipt = json.ToString("receipt");
         }
 
 #if UNITY_IOS
@@ -169,6 +174,7 @@ namespace OnePF
             j["originalJson"] = OriginalJson;
             j["signature"] = Signature;
             j["appstoreName"] = AppstoreName;
+            j["receipt"] = Receipt;
             return j.serialized;
         }
     }

--- a/unity_plugin/unity_src/Assets/Plugins/iOS/AppStoreDelegate.mm
+++ b/unity_plugin/unity_src/Assets/Plugins/iOS/AppStoreDelegate.mm
@@ -244,10 +244,24 @@ NSMutableArray* m_skuMap;
 				break;
                 
 			case SKPaymentTransactionStatePurchased:
-                [self storePurchase:transaction.payment.productIdentifier];
-                UnitySendMessage(EventHandler, "OnPurchaseSucceeded", MakeStringCopy([transaction.payment.productIdentifier UTF8String]));
-                [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
-                break;
+				[self storePurchase:transaction.payment.productIdentifier];
+				NSDictionary *requestContents = [NSDictionary dictionaryWithObjectsAndKeys:
+												 transaction.payment.productIdentifier, @"sku",
+												 [transaction.transactionReceipt base64Encoding], @"receipt",
+												 nil];
+				NSError *error;
+				NSData *requestData = [NSJSONSerialization dataWithJSONObject:requestContents
+																	  options:0
+																		error:&error];
+				if (!requestData) {
+					NSLog(@"Got an error while creating the JSON object: %@", error);
+					return;
+				}
+				
+				NSString * jsonString = [[NSString alloc] initWithData:requestData encoding:NSUTF8StringEncoding];
+				UnitySendMessage(EventHandler, "OnPurchaseSucceeded", MakeStringCopy([jsonString UTF8String]));
+				[[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+				break;
 		}
 	}
 }


### PR DESCRIPTION
Pass an receipt argument as base64 encoded string for iOS server-side validation. Based on another pull request by this guy @thuydx55 and fixed compilation error