### PR TITLE
Restore store sku to sku conversion in OnPurchaseSucceeded for iOS

### DIFF
--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/OpenIABEventManager.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/OpenIABEventManager.cs
@@ -218,7 +218,7 @@ public class OpenIABEventManager : MonoBehaviour
     {
         if (purchaseSucceededEvent != null)
         {
-            purchaseSucceededEvent(new Purchase(json));
+            purchaseSucceededEvent(new Purchase(new JSON(json)));
         }
     }
 

--- a/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Purchase.cs
+++ b/unity_plugin/unity_src/Assets/Plugins/OpenIAB/Purchase.cs
@@ -108,6 +108,7 @@ namespace OnePF
             OriginalJson = json.ToString("originalJson");
             Signature = json.ToString("signature");
             AppstoreName = json.ToString("appstoreName");
+            Receipt = json.ToString("receipt");
 
 			Sku = OpenIAB_iOS.StoreSku2Sku(Sku);
         }


### PR DESCRIPTION
Fix incorrect purchase object construction in OnPurchaseSucceeded for iOS. Sku field was inited with store sku of the product instead of mapped sku. This resulted consuming product not working on iOS. Was broken by pull request #46, corresponding reported issue #83.